### PR TITLE
fix: ensure results are consistent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,5 +48,12 @@ module.exports = async (inventory, opts, { headers, ...gotOpts } = {}) => {
   const nRequests = Math.ceil(page.total / ITEMS_PER_PAGE) - 1
   const offsets = [...Array(nRequests).keys()].map(n => (n + 1) * page.items.length)
   const pages = await Promise.all(offsets.map(paginate))
-  return pages.reduce((acc, { items }) => acc.concat(items), page.items)
+
+  return [page, ...pages].reduce((acc, page) => {
+    page.items.forEach(item => {
+      const isAlready = acc.some(({ VIN }) => VIN === item.VIN)
+      if (!isAlready) acc.push(item)
+    })
+    return acc
+  }, [])
 }

--- a/test/index.js
+++ b/test/index.js
@@ -30,16 +30,19 @@ test('inventory should be valid', async t => {
 })
 
 test('ensure results are consistent', async t => {
-  const results = await teslaInventory('ie', {
+  const results = await teslaInventory('us', {
     condition: 'used',
-    model: 'y'
+    model: '3'
   })
 
-  t.true(results.every(item => item.Model === 'my'))
+  t.true(results.every(item => item.Model === 'm3'))
+
+  const vins = results.map(item => item.VIN)
+  t.is(vins.length, [...new Set(vins)].length)
 })
 
 test('Model S', async t => {
-  const results = await teslaInventory('fr', {
+  const results = await teslaInventory('us', {
     condition: 'used',
     model: 's'
   })
@@ -48,7 +51,7 @@ test('Model S', async t => {
 })
 
 test('Model 3', async t => {
-  const results = await teslaInventory('fr', {
+  const results = await teslaInventory('us', {
     condition: 'used',
     model: '3'
   })
@@ -57,7 +60,7 @@ test('Model 3', async t => {
 })
 
 test('Model X', async t => {
-  const results = await teslaInventory('fr', {
+  const results = await teslaInventory('us', {
     condition: 'used',
     model: 'x'
   })


### PR DESCRIPTION
inventories with lot of items (like `us`) tend to return duplicate items