### PR TITLE
fix: use length check for single-char model code prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These options can be:
 
 - **arrangeby**: Price
 - **condition**: used|new
-- **model**: ms|mx|m3
+- **model**: ms|mx|m3|ct
 - **order**: asc|desc
 
 #### fetcherOpts

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These options can be:
 
 - **arrangeby**: Price
 - **condition**: used|new
-- **model**: ms|mx|m3|ct
+- **model**: ms|mx|m3|my|ct
 - **order**: asc|desc
 
 #### fetcherOpts

--- a/scripts/prices.js
+++ b/scripts/prices.js
@@ -8,7 +8,7 @@ const path = require('path')
 
 const { sortObjectByKey } = require('./util')
 
-const MODEL_LETTER = ['s', '3', 'x', 'y']
+const MODEL_LETTER = ['s', '3', 'x', 'y', 'ct']
 
 const MODEL_CONDITION = ['used', 'new']
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports =
         throw new TypeError(`Tesla inventory \`${inventory}\` not found!`)
       }
 
-      if (opts.model && !opts.model.startsWith('m')) {
+      if (opts.model && opts.model.length === 1) {
         opts.model = `m${opts.model}`
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -132,3 +132,12 @@ test('Model Y new (Puerto Rico)', async t => {
 
   t.true(results.every(item => item.Model === 'my'))
 })
+
+test('Cybertruck new', async t => {
+  const results = await teslaInventory('us', {
+    condition: 'new',
+    model: 'ct'
+  })
+
+  t.true(results.every(item => item.Model === 'ct'))
+})


### PR DESCRIPTION
Hello,

Cybertruck aren't pulled from inventory on countries selling it.

Model codes are either single-char shorthands (3, y, s, x) or full codes (m3, my, ms, mx, ct). The old !startsWith('m') check assumed every non-m code was a shorthand needing an m prefix, but the Cybertruck's code is ct, which got mangled into mct and broke its inventory lookups.

Switching to length === 1 only prefixes the actual single-character shorthands, leaving ct (and any other multi-char code) intact. Cybertruck queries now resolve correctly.

Best regards,