### PR TITLE
docs: fix broken link to inventories file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The fetcher function used for performing the networking calls. It should return 
 *Required*<br>
 Type: `string`
 
-The Tesla Inventory identifier, see [`inventories`](/inventories.js).
+The Tesla Inventory identifier, see [`inventories`](/src/inventories/index.js).
 
 #### query
 


### PR DESCRIPTION
The README points to `/inventories.js`, which no longer exists (it 404s on GitHub).

The file now lives at [`src/inventories/index.js`](/src/inventories/index.js) and is exposed publicly via the `./inventories` export in `package.json`. This updates the link to the correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)